### PR TITLE
Set HTML title to project name

### DIFF
--- a/src/html/partials/head.html
+++ b/src/html/partials/head.html
@@ -8,7 +8,7 @@
         <meta http-equiv="x-ua-compatible" content="ie=edge">
         <meta name="viewport" content="width=device-width, initial-scale=1">
 
-        <title>Chippewa</title>
+        <title>Bias and Equity in Tech Reading List</title>
         <meta name="description" content="">
 
         <!-- The compiled CSS file -->


### PR DESCRIPTION
I noticed this when the tab in Safari didn't match the contents!